### PR TITLE
Fixed the game would freeze when the mouse moving over the window.

### DIFF
--- a/src/Animate.hs
+++ b/src/Animate.hs
@@ -120,6 +120,13 @@ mkInitAndGetTimeInput win = do
 
     -- Next delta time and input
     let getTimeInput _ = do
+          -- Seems as if we either have to yield or wait for a tick in order
+          -- to ensure that the thread receiving events gets a chance to
+          -- work. For some reason, yielding seems to result in window close
+          -- events getting through, wheras waiting often means they don't.
+          -- Maybe the process typically dies before the waiting time is up in
+          -- the latter case?
+          HGL.getWindowTick win
           -- Get time
           tp <- readIORef tpRef
           t  <- getElapsedTime `repeatUntil` (/= tp) -- Wrap around possible!
@@ -178,15 +185,7 @@ getWinInput win weBufRef = do
                 Just (HGL.MouseMove {}) -> mmFilter mwe'
                 Just _                  -> writeIORef weBufRef mwe'
                                            >> return jmme
-
-        -- Seems as if we either have to yield or wait for a tick in order
-        -- to ensure that the thread receiving events gets a chance to
-        -- work. For some reason, yielding seems to result in window close
-        -- events getting through, wheras waiting often means they don't.
-        -- Maybe the process typically dies before the waiting time is up in
-        -- the latter case?
         gwi win = do
-            HGL.getWindowTick win
             mwe <- HGL.maybeGetWindowEvent win
             return mwe
 


### PR DESCRIPTION
## Phenomenon:

After executing spaceInvaders.exe, if you moving the mouse over the window, the game freezes!

## Root cause:

When Yampa's sensing action takes window inputs, if the input is a `HGL.MouseMove` event, it will call `mmFilter` to consume all subsequent "redundant" `HGL.MouseMove` events. If there are several hundred `HGL.MouseMove` events, `mmFilter` will be recursively called several hundreds of times.

The`mmFilter` further calls `gwi win` to take events, and `gwi win` calls `HGL.getWindowTick win` to yield some time slices to ensure that the thread actually receiving WM events gets a chance to work.

### This leads to a problem:

Since `HGL.getWindowTick win` is a blocking operation (i.e. waiting for a tickRate time), if there are 100 subsequent `HGL.MouseMove`, it will wait for "100 x tickRate time", which is unacceptable. Moreover, during this waiting period, there might be further mouse move events generated!

This patch fixed the issue by placing `HGL.getWindowTick win` at the beginning of a frame, i.e. at the entry point of `getTimeInput`, rather than inside `gwi win`.

Related issue: https://github.com/ivanperez-keera/SpaceInvaders/issues/44

---

P.s. This PR is the same as the old one https://github.com/ivanperez-keera/SpaceInvaders/pull/45. I have to open a new PR because the old PR https://github.com/ivanperez-keera/SpaceInvaders/pull/45 used `develop` branch, which is difficult to maintain (rename branch close the old PR automatically).
